### PR TITLE
disable fs cache for long caching SparkSession to avoid token expirly

### DIFF
--- a/src/main/scala/org/apache/spark/KyuubiSparkUtil.scala
+++ b/src/main/scala/org/apache/spark/KyuubiSparkUtil.scala
@@ -69,6 +69,8 @@ object KyuubiSparkUtil extends Logging {
   val USE_DB: Regex = """use:([^=]+)""".r
   val QUEUE = SPARK_PREFIX + YARN_PREFIX + "queue"
   val DEPRECATED_QUEUE = "mapred.job.queue.name"
+  val HDFS_CLIENT_CACHE = SPARK_HADOOP_PREFIX + "fs.hdfs.impl.disable.cache"
+  val HDFS_CLIENT_CACHE_DEFAULT = "true"
 
   // Runtime Spark Version
   val SPARK_VERSION = org.apache.spark.SPARK_VERSION

--- a/src/main/scala/org/apache/spark/KyuubiSparkUtil.scala
+++ b/src/main/scala/org/apache/spark/KyuubiSparkUtil.scala
@@ -71,6 +71,8 @@ object KyuubiSparkUtil extends Logging {
   val DEPRECATED_QUEUE = "mapred.job.queue.name"
   val HDFS_CLIENT_CACHE = SPARK_HADOOP_PREFIX + "fs.hdfs.impl.disable.cache"
   val HDFS_CLIENT_CACHE_DEFAULT = "true"
+  val FILE_CLIENT_CACHE = SPARK_HADOOP_PREFIX + "fs.file.impl.disable.cache"
+  val FILE_CLIENT_CACHE_DEFAULT = "true"
 
   // Runtime Spark Version
   val SPARK_VERSION = org.apache.spark.SPARK_VERSION

--- a/src/main/scala/yaooqinn/kyuubi/server/KyuubiServer.scala
+++ b/src/main/scala/yaooqinn/kyuubi/server/KyuubiServer.scala
@@ -129,6 +129,8 @@ object KyuubiServer extends Logging {
     if (UserGroupInformation.isSecurityEnabled) {
       conf.setIfMissing(KyuubiSparkUtil.HDFS_CLIENT_CACHE,
         KyuubiSparkUtil.HDFS_CLIENT_CACHE_DEFAULT)
+      conf.setIfMissing(KyuubiSparkUtil.FILE_CLIENT_CACHE,
+        KyuubiSparkUtil.FILE_CLIENT_CACHE_DEFAULT)
     }
   }
 

--- a/src/main/scala/yaooqinn/kyuubi/server/KyuubiServer.scala
+++ b/src/main/scala/yaooqinn/kyuubi/server/KyuubiServer.scala
@@ -125,6 +125,11 @@ object KyuubiServer extends Logging {
 
     conf.setIfMissing(
       KyuubiSparkUtil.SPARK_LOCAL_DIR, conf.get(KyuubiConf.BACKEND_SESSION_LOCAL_DIR.key))
+
+    if (UserGroupInformation.isSecurityEnabled) {
+      conf.setIfMissing(KyuubiSparkUtil.HDFS_CLIENT_CACHE,
+        KyuubiSparkUtil.HDFS_CLIENT_CACHE_DEFAULT)
+    }
   }
 
   private[kyuubi] def validate(): Unit = {

--- a/src/test/scala/org/apache/spark/KyuubiSparkUtilSuite.scala
+++ b/src/test/scala/org/apache/spark/KyuubiSparkUtilSuite.scala
@@ -195,5 +195,7 @@ class KyuubiSparkUtilSuite extends SparkFunSuite with Logging {
   test("testHDFS_CLIENT_CACHE") {
     assert(KyuubiSparkUtil.HDFS_CLIENT_CACHE === "spark.hadoop.fs.hdfs.impl.disable.cache")
     assert(KyuubiSparkUtil.HDFS_CLIENT_CACHE_DEFAULT.toBoolean)
+    assert(KyuubiSparkUtil.FILE_CLIENT_CACHE === "spark.hadoop.fs.file.impl.disable.cache")
+    assert(KyuubiSparkUtil.FILE_CLIENT_CACHE_DEFAULT.toBoolean)
   }
 }

--- a/src/test/scala/org/apache/spark/KyuubiSparkUtilSuite.scala
+++ b/src/test/scala/org/apache/spark/KyuubiSparkUtilSuite.scala
@@ -191,4 +191,9 @@ class KyuubiSparkUtilSuite extends SparkFunSuite with Logging {
     KyuubiSparkUtil.addShutdownHook(f)
     assert(y === 0)
   }
+
+  test("testHDFS_CLIENT_CACHE") {
+    assert(KyuubiSparkUtil.HDFS_CLIENT_CACHE === "spark.hadoop.fs.hdfs.impl.disable.cache")
+    assert(KyuubiSparkUtil.HDFS_CLIENT_CACHE_DEFAULT.toBoolean)
+  }
 }


### PR DESCRIPTION
former version of Kyuubi should set ` spark.hadoop.fs.hdfs.disable.cache=true` manully