### PR TITLE
Fix EmbeddedZkServerSuite embedded zookeeper server NPE problem

### DIFF
--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/server/EmbeddedZkServer.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/server/EmbeddedZkServer.scala
@@ -52,6 +52,11 @@ class EmbeddedZkServer private(name: String) extends AbstractService(name) with 
 
   override def start(): Unit = {
     server.start()
+    // Just a tradeoff, otherwise we may get NPE if we call stop() immediately.
+    // (e.g. the unit test EmbeddedZkServerSuite)
+    // TestingZooKeeperMain has a bug that the CountDownLatch released before cnxnFactory inited.
+    // More details could see TestingZooKeeperMain.runFromConfig.
+    Thread.sleep(5000)
     info(s"$getName is started at $getConnectString")
     super.start()
   }

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/server/EmbeddedZkServer.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/server/EmbeddedZkServer.scala
@@ -52,17 +52,18 @@ class EmbeddedZkServer private(name: String) extends AbstractService(name) with 
 
   override def start(): Unit = {
     server.start()
-    // Just a tradeoff, otherwise we may get NPE if we call stop() immediately.
-    // (e.g. the unit test EmbeddedZkServerSuite)
-    // TestingZooKeeperMain has a bug that the CountDownLatch released before cnxnFactory inited.
-    // More details could see TestingZooKeeperMain.runFromConfig.
-    Thread.sleep(5000)
     info(s"$getName is started at $getConnectString")
     super.start()
   }
 
   override def stop(): Unit = {
     if (server != null) {
+      // Just a tradeoff, otherwise we may get NPE if we call stop() immediately.
+      // (e.g. the unit test EmbeddedZkServerSuite)
+      // TestingZooKeeperMain has a bug that the CountDownLatch released before cnxnFactory inited.
+      // More details could see TestingZooKeeperMain.runFromConfig.
+      while (getStartTime > 0 && System.currentTimeMillis() - getStartTime < 5000) {
+      }
       server.close()
       server = null
     }


### PR DESCRIPTION
We may get below problem when execute `EmbeddedZkServerSuite`.
```
java.lang.NullPointerException
	at org.apache.zookeeper.server.ZooKeeperServerMain.shutdown(ZooKeeperServerMain.java:132)
	at org.apache.curator.test.TestingZooKeeperMain.close(TestingZooKeeperMain.java:122)
	at org.apache.curator.test.TestingZooKeeperServer.stop(TestingZooKeeperServer.java:110)
	at org.apache.curator.test.TestingZooKeeperServer.close(TestingZooKeeperServer.java:122)
	at org.apache.curator.test.TestingServer.close(TestingServer.java:183)
	at org.apache.kyuubi.ha.server.EmbeddedZkServer.stop(EmbeddedZkServer.scala:61)
	at org.apache.kyuubi.ha.server.EmbeddedZkServerSuite.$anonfun$new$1(EmbeddedZkServerSuite.scala:47)
```

The reason is the curator bug that `TestingZooKeeperMain` has a bad lock for cnxnFactory.