### PR TITLE
Support launch SparkProcessBuilder with keytab and principal

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/SparkSQLEngineListenerSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/SparkSQLEngineListenerSuite.scala
@@ -33,7 +33,7 @@ class SparkSQLEngineListenerSuite extends KyuubiFunSuite {
 
   test("application end") {
     val spark = SparkSession
-      .builder().master("local").getOrCreate()
+      .builder().master("local").config("spark.ui.port", "0").getOrCreate()
 
     val engine = new SparkSQLEngine(spark)
     engine.initialize(KyuubiConf())

--- a/kyuubi-main/pom.xml
+++ b/kyuubi-main/pom.xml
@@ -65,6 +65,16 @@
             <artifactId>hive-jdbc</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-minikdc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-service</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/kyuubi-main/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
+++ b/kyuubi-main/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
@@ -84,16 +84,11 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper {
     val b3 = new SparkProcessBuilder("kentyao", conf2)
     assert(b3.toString.contains("--proxy-user kentyao"))
 
-    val conf3 = conf ++ Map("spark.kerberos.principal" -> testPrincipal,
-      "spark.kerberos.keytab" -> "testKeytab")
-    val b4 = new SparkProcessBuilder(Utils.currentUser, conf3)
-    assert(!b4.toString.contains("--proxy-user kentyao"))
-
     tryWithSecurityEnabled {
-      val conf33 = conf ++ Map("spark.kerberos.principal" -> testPrincipal,
+      val conf3 = conf ++ Map("spark.kerberos.principal" -> testPrincipal,
         "spark.kerberos.keytab" -> "testKeytab")
-      val b44 = new SparkProcessBuilder(Utils.currentUser, conf33)
-      assert(b44.toString.contains("--proxy-user kentyao"))
+      val b4 = new SparkProcessBuilder(Utils.currentUser, conf3)
+      assert(b4.toString.contains(s"--proxy-user ${Utils.currentUser}"))
 
       val conf4 = conf ++ Map("spark.kerberos.principal" -> testPrincipal,
         "spark.kerberos.keytab" -> testKeytab)
@@ -103,6 +98,5 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper {
       val b6 = new SparkProcessBuilder(ServiceUtils.getShortName(testPrincipal), conf4)
       assert(!b6.toString.contains("--proxy-user kentyao"))
     }
-
   }
 }


### PR DESCRIPTION
Temporary support for long-running engine instances in kerberized clusters. 

When the engine launched via proxy-user and the token expired, currently spark does not support update tokens for proxy users. we can enable session-level keytabs and principals

They can be  configured on the system side with default values in the form of user-defaults, like https://kyuubi.readthedocs.io/en/stable/deployment/settings.html#user-defaults

Or via JDBC Connection URL accordingly, like https://kyuubi.readthedocs.io/en/stable/deployment/settings.html#via-jdbc-connection-url

Both of them need to ensure the keytab is valid and reachable for now. Otherwise, we will fallback to the proxy user way.

