### PR TITLE
Handle InvocationTargetException and UndeclaredThrowableException in KSE

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/KyuubiSQLExceptionSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/KyuubiSQLExceptionSuite.scala
@@ -62,5 +62,8 @@ class KyuubiSQLExceptionSuite extends KyuubiFunSuite {
     val ke = KyuubiSQLException(ite2)
     assert(ke.getMessage == theCause.getMessage)
     assert(ke.getCause == theCause)
+
+    val cornerCase = new InvocationTargetException(null)
+    assert(KyuubiSQLException(cornerCase).getCause === cornerCase)
   }
 }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/KyuubiSQLExceptionSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/KyuubiSQLExceptionSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.kyuubi
 
+import java.lang.reflect.{InvocationTargetException, UndeclaredThrowableException}
+
 import org.apache.hive.service.rpc.thrift.TStatusCode
 
 class KyuubiSQLExceptionSuite extends KyuubiFunSuite {
@@ -49,5 +51,16 @@ class KyuubiSQLExceptionSuite extends KyuubiFunSuite {
     val e5 = KyuubiSQLException(e0)
     assert(e5.getMessage === msg0)
     assert(e5.getCause === e0)
+  }
+
+  test("find the root cause") {
+    val theCause = new RuntimeException("this is just a dummy message but shall be seen")
+    val ite1 = new InvocationTargetException(theCause)
+    val ute1 = new UndeclaredThrowableException(ite1)
+    val ute2 = new UndeclaredThrowableException(ute1)
+    val ite2 = new InvocationTargetException(ute2)
+    val ke = KyuubiSQLException(ite2)
+    assert(ke.getMessage == theCause.getMessage)
+    assert(ke.getCause == theCause)
   }
 }


### PR DESCRIPTION
In Kyuubi, we use KSE to wark with TStatus.

This PR adds a function to extract the root cause from InvocationTargetException and UndeclaredThrowableException, this mostly happens when spark talks to Hive Metastore where has a lot of innovation by  java reflection calls .

Otherwise, the end-users may get error like this
```sql
Error: Error opening session SessionHandle [b9d43f01-4e8d-4cc9-a69a-9b492b565c4c] for username due to Error opening session SessionHandle [2b00f3d2-448b-432b-a470-08321b21535d] for username: null (state=,code=0)
```