### PR TITLE
exclude hbase-* from hive-jdbc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,12 @@
                 <groupId>org.apache.hive</groupId>
                 <artifactId>hive-jdbc</artifactId>
                 <version>${hive.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.hbase</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Even we don't want to spend efforts on `hive-jdbc`, but without this exclude, IDEA will keep complaining
```
Cannot resolve jdk.tools:jdk.tools:1.7
```