### PR TITLE
Fix high cpu load due to log capture thread not release

### DIFF
--- a/kyuubi-main/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
+++ b/kyuubi-main/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
@@ -56,6 +56,7 @@ trait ProcBuilder {
   }
 
   @volatile private var error: Throwable = UNCAUGHT_ERROR
+  // Visible for test
   private[kyuubi] var logCaptureThread: Thread = null
 
   final def start: Process = synchronized {

--- a/kyuubi-main/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
+++ b/kyuubi-main/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
@@ -84,8 +84,6 @@ trait ProcBuilder {
 
             error = KyuubiSQLException(sb.toString())
           }
-          // No need to always read log
-          Thread.sleep(200)
           line = reader.readLine()
         }
       } catch {

--- a/kyuubi-main/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-main/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -129,6 +129,8 @@ class KyuubiSessionImpl(
           val Some((host, port)) = sh
           openSession(host, port)
         } finally {
+          // we must close the process builder whether session open is success or failure since
+          // we have a log capture thread in process builder.
           builder.close()
         }
     }

--- a/kyuubi-main/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
+++ b/kyuubi-main/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
@@ -99,4 +99,20 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper {
       assert(!b6.toString.contains("--proxy-user kentyao"))
     }
   }
+
+  test("log capture should release after close") {
+    val process = new FakeSparkProcessBuilder
+    try {
+      val subProcess = process.start
+      assert(!process.logCaptureThread.isInterrupted)
+      subProcess.waitFor(3, TimeUnit.SECONDS)
+    } finally {
+      process.close()
+    }
+    assert(process.logCaptureThread.isInterrupted)
+  }
+}
+
+class FakeSparkProcessBuilder extends SparkProcessBuilder("fake", Map.empty) {
+  override protected def commands: Array[String] = Array("ls")
 }


### PR DESCRIPTION
We will create a new log capture thread when open a new session, but we forgot release the thread after session opened success or failure.

Note that, we don't need to wait sub process finished because the log capture lifecycle is `SESSION_CREATE`  -> `SESSION_OPEN`. After `SESSION_OPEN` the log is controled by session.