### PR TITLE
Downgrade libthrift:0.9.3 due to THRIFT-4805

### DIFF
--- a/kyuubi-common/pom.xml
+++ b/kyuubi-common/pom.xml
@@ -70,16 +70,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.thrift</groupId>
-            <artifactId>libthrift</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.thrift</groupId>
-            <artifactId>libfb303</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-minikdc</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,6 @@
         <curator.version>2.7.1</curator.version>
         <hadoop.version>2.7.4</hadoop.version>
         <hive.version>2.3.7</hive.version>
-        <libfb303.version>0.9.3</libfb303.version>
-        <libthrift.version>0.12.0</libthrift.version>
         <netty3.version>3.7.0.Final</netty3.version>
         <spark.version>3.0.1</spark.version>
         <slf4j.version>1.7.30</slf4j.version>
@@ -322,34 +320,33 @@
                 <version>${spark.version}</version>
             </dependency>
 
+            <!--
+              because of THRIFT-4805, we don't upgrade to libthrift:0.12.0,
+              because of THRIFT-5274, we don't upgrade to libthrift:0.13.0,
+              so just keep hive-service-rpc:2.3.7 transitive dependency libthrift:0.9.3
+            -->
             <dependency>
                 <groupId>org.apache.hive</groupId>
                 <artifactId>hive-service-rpc</artifactId>
                 <version>${hive.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
+                        <groupId>commons-codec</groupId>
+                        <artifactId>commons-codec</artifactId>
                     </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.thrift</groupId>
-                <artifactId>libthrift</artifactId>
-                <version>${libthrift.version}</version>
-                <exclusions>
+                    <exclusion>
+                        <groupId>commons-cli</groupId>
+                        <artifactId>commons-cli</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>commons-logging</groupId>
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>tomcat</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.thrift</groupId>
-                <artifactId>libfb303</artifactId>
-                <version>${libfb303.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
because of THRIFT-4805, we don't upgrade to libthrift:0.12.0,
because of THRIFT-5274, we don't upgrade to libthrift:0.13.0,
so just keep hive-service-rpc:2.3.7 transitive dependency libthrift:0.9.3