### PR TITLE
[KYUUBI #284][FOLLOWUP] Fix a race condition in engine redirect log file initialization

### DIFF
--- a/kyuubi-main/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
+++ b/kyuubi-main/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
@@ -17,7 +17,7 @@
 
 package org.apache.kyuubi.engine
 
-import java.io.{File, IOException}
+import java.io.{File, FilenameFilter, IOException}
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
 
@@ -138,7 +138,11 @@ object ProcBuilder {
       workingDir: Path, module: String, processLogRetainTimeMillis: Long): File = synchronized {
     val currentTime = System.currentTimeMillis()
     val processLogPath = workingDir
-    val totalExistsFile = processLogPath.toFile.listFiles()
+    val totalExistsFile = processLogPath.toFile.listFiles(new FilenameFilter() {
+      override def accept(dir: File, name: String): Boolean = {
+        name.startsWith(module)
+      }
+    })
     val sorted = totalExistsFile.sortBy(_.getName.split("\\.").last.toInt)
     val nextIndex = if (sorted.isEmpty) {
       0

--- a/kyuubi-main/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
+++ b/kyuubi-main/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
@@ -114,43 +114,50 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper {
   }
 
   test(s"sub process log should be overwritten") {
-    val pool = Executors.newFixedThreadPool(3)
-    val fakeWorkDir = Files.createTempDirectory("fake")
-    val dir = fakeWorkDir.toFile
-    try {
-      assert(dir.list().length == 0)
+    def atomicTest(): Unit = {
+      val pool = Executors.newFixedThreadPool(3)
+      val fakeWorkDir = Files.createTempDirectory("fake")
+      val dir = fakeWorkDir.toFile
+      try {
+        assert(dir.list().length == 0)
 
-      val longTimeFile = new File(dir, "kyuubi-spark-sql-engine.log.7")
-      longTimeFile.createNewFile()
-      Thread.sleep(3000)
+        val longTimeFile = new File(dir, "kyuubi-spark-sql-engine.log.7")
+        longTimeFile.createNewFile()
+        longTimeFile.setLastModified(System.currentTimeMillis() - 3600000)
 
-      val shortTimeFile = new File(dir, "kyuubi-spark-sql-engine.log.0")
-      shortTimeFile.createNewFile()
+        val shortTimeFile = new File(dir, "kyuubi-spark-sql-engine.log.0")
+        shortTimeFile.createNewFile()
 
-      val config = Map(s"spark.${SESSION_SUBMIT_LOG_RETAIN_MILLIS.key}" -> "3000")
-      (1 to 10).foreach { _ =>
-        pool.execute(new Runnable {
-          override def run(): Unit = {
-            val pb = new FakeSparkProcessBuilder(config) {
-              override val workingDir: Path = fakeWorkDir
+        val config = Map(s"spark.${SESSION_SUBMIT_LOG_RETAIN_MILLIS.key}" -> "20000")
+        (1 to 10).foreach { _ =>
+          pool.execute(new Runnable {
+            override def run(): Unit = {
+              val pb = new FakeSparkProcessBuilder(config) {
+                override val workingDir: Path = fakeWorkDir
+              }
+              try {
+                val p = pb.start
+                p.waitFor()
+              } finally {
+                pb.close()
+              }
             }
-            try {
-              val p = pb.start
-              p.waitFor()
-            } finally {
-              pb.close()
-            }
-          }
-        })
+          })
+        }
+        pool.shutdown()
+        while (!pool.isTerminated) {
+          Thread.sleep(100)
+        }
+        assert(dir.listFiles().length == 10 + 1)
+      } finally {
+        dir.listFiles().foreach(_.delete())
+        dir.delete()
       }
-      pool.shutdown()
-      while (!pool.isTerminated) {
-        Thread.sleep(100)
-      }
-      assert(dir.listFiles().length == 10 + 1)
-    } finally {
-      dir.listFiles().foreach(_.delete())
-      dir.delete()
+    }
+
+    // this loop is to promise we have a good test
+    (1 to 10).foreach { _ =>
+      atomicTest()
     }
   }
 }

--- a/kyuubi-main/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
+++ b/kyuubi-main/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
@@ -121,7 +121,7 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper {
       try {
         assert(dir.list().length == 0)
 
-        val longTimeFile = new File(dir, "kyuubi-spark-sql-engine.log.7")
+        val longTimeFile = new File(dir, "kyuubi-spark-sql-engine.log.1")
         longTimeFile.createNewFile()
         longTimeFile.setLastModified(System.currentTimeMillis() - 3600000)
 


### PR DESCRIPTION
![ulysses-you](https://badgen.net/badge/Hello/ulysses-you/green) [![PR 289](https://badgen.net/badge/Preview/PR%20289/blue)](https://github.com/yaooqinn/kyuubi/pull/289) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=yaooqinn&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
-->

### Please add issue ID here?

fixes #284
closes #289

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the user case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix the problem if some thread overwrite the same file.

### Test Plan:
- Add some test cases that check the changes thoroughly including negative and positive cases if possible
- Add screenshots for manual tests if appropriate
- [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request