### PR TITLE
[KYUUBI-280] Align Operation GET_SCHEMAS * behavior with Hive

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetColumns.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetColumns.scala
@@ -17,7 +17,6 @@
 
 package org.apache.kyuubi.engine.spark.operation
 
-
 import java.util.regex.Pattern
 
 import scala.collection.mutable.ArrayBuffer

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetColumns.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetColumns.scala
@@ -17,10 +17,12 @@
 
 package org.apache.kyuubi.engine.spark.operation
 
+
 import java.util.regex.Pattern
 
 import scala.collection.mutable.ArrayBuffer
 
+import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType, CalendarIntervalType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, MapType, NullType, NumericType, ShortType, StringType, StructField, StructType, TimestampType}
 
@@ -187,7 +189,9 @@ class GetColumns(
 
       val gviews = new ArrayBuffer[Row]()
       val globalTmpDb = catalog.globalTempViewManager.database
-      if (Pattern.compile(schemaPattern).matcher(globalTmpDb).matches()) {
+      if (StringUtils.isEmpty(schemaName) || schemaName == "*"
+        || Pattern.compile(convertSchemaPattern(schemaName, false))
+        .matcher(globalTmpDb).matches()) {
         catalog.globalTempViewManager.listViewNames(tablePattern).foreach { v =>
           catalog.globalTempViewManager.get(v).foreach { plan =>
             plan.schema.zipWithIndex

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetSchemas.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetSchemas.scala
@@ -45,10 +45,7 @@ class GetSchemas(spark: SparkSession, session: Session, catalogName: String, sch
       val schemaPattern = convertSchemaPattern(schema)
       val databases = spark.sessionState.catalog.listDatabases(schemaPattern)
       val globalTmpViewDb = spark.sessionState.catalog.globalTempViewManager.database
-      if (
-        // Hive Metastore treat empty schema or * as get all databases,
-        // see detail at [[org.apache.hadoop.hive.metastore.ObjectStore#getDatabase]]
-        StringUtils.isEmpty(schema) || schema == "*"
+      if (StringUtils.isEmpty(schema) || schema == "*"
         || Pattern.compile(convertSchemaPattern(schema, false))
         .matcher(globalTmpViewDb).matches()) {
         iter = (databases :+ globalTmpViewDb).map(Row(_, "")).toList.iterator

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetTables.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetTables.scala
@@ -19,6 +19,7 @@ package org.apache.kyuubi.engine.spark.operation
 
 import java.util.regex.Pattern
 
+import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType
 import org.apache.spark.sql.types.StructType
@@ -51,7 +52,7 @@ class GetTables(
       .add(TABLE_NAME, "string", nullable = true, "Table name.")
       .add(TABLE_TYPE, "string", nullable = true, "The table type, e.g. \"TABLE\", \"VIEW\"")
       .add(REMARKS, "string", nullable = true, "Comments about the table.")
-      .add("TYPE_CAT", "string", nullable = true, "The types catalog." )
+      .add("TYPE_CAT", "string", nullable = true, "The types catalog.")
       .add("TYPE_SCHEM", "string", nullable = true, "the types schema (may be null)")
       .add("TYPE_NAME", "string", nullable = true, "Type name.")
       .add("SELF_REFERENCING_COL_NAME", "string", nullable = true,
@@ -82,8 +83,9 @@ class GetTables(
 
       val views = if (matched(CatalogTableType.VIEW)) {
         val globalTempViewDb = catalog.globalTempViewManager.database
-        (if (Pattern.compile(convertSchemaPattern(schema, datanucleusFormat = false))
-            .matcher(globalTempViewDb).matches()) {
+        (if (StringUtils.isEmpty(schema) || schema == "*"
+          || Pattern.compile(convertSchemaPattern(schema, datanucleusFormat = false))
+          .matcher(globalTempViewDb).matches()) {
           catalog.listTables(globalTempViewDb, tablePattern, includeLocalTempViews = true)
         } else {
           catalog.listLocalTempViews(tablePattern)

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
@@ -137,9 +137,6 @@ class SparkOperationSuite extends WithSparkSQLEngine {
         assert(pos === 18, "all columns should have been verified")
       }
 
-      val e = intercept[HiveSQLException](metaData.getColumns(null, "*", null, null))
-      assert(e.getCause.getMessage contains "Dangling meta character '*' near index 0\n*\n^")
-
       val e1 = intercept[HiveSQLException](metaData.getColumns(null, null, null, "*"))
       assert(e1.getCause.getMessage contains "Dangling meta character '*' near index 0\n*\n^")
     }

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
@@ -84,8 +84,8 @@ class SparkOperationSuite extends WithSparkSQLEngine {
 
       val metaData = statement.getConnection.getMetaData
 
-      Seq("%", null, ".*", "c.*") foreach { pattern =>
-        val rowSet = metaData.getColumns("", dftSchema, tableName, pattern)
+      Seq("%", null, ".*", "c.*") foreach { columnPattern =>
+        val rowSet = metaData.getColumns("", dftSchema, tableName, columnPattern)
 
         import java.sql.Types._
         val expectedJavaTypes = Seq(BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, FLOAT, DOUBLE,
@@ -136,6 +136,9 @@ class SparkOperationSuite extends WithSparkSQLEngine {
 
         assert(pos === 18, "all columns should have been verified")
       }
+
+      val rowSet = metaData.getColumns(null, "*", "not_exist", "not_exist")
+      assert(!rowSet.next())
 
       val e1 = intercept[HiveSQLException](metaData.getColumns(null, null, null, "*"))
       assert(e1.getCause.getMessage contains "Dangling meta character '*' near index 0\n*\n^")

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/JDBCTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/JDBCTests.scala
@@ -163,25 +163,33 @@ trait JDBCTests extends KyuubiFunSuite {
       }
       assert(i === 4)
 
-      val rs3 = metaData.getTables(null, null, "table%", Array("VIEW"))
-      assert(!rs3.next())
+      val rs3 = metaData.getTables(null, "*", "*", Array("VIEW"))
+      i = 2
+      while(rs3.next()) {
+        assert(rs3.getString(TABLE_NAME) == tables(i))
+        i += 1
+      }
+      assert(i === 4)
 
-      val rs4 = metaData.getTables(null, null, "table%", Array("TABLE"))
+      val rs4 = metaData.getTables(null, null, "table%", Array("VIEW"))
+      assert(!rs4.next())
+
+      val rs5 = metaData.getTables(null, "*", "table%", Array("VIEW"))
+      assert(!rs5.next())
+
+      val rs6 = metaData.getTables(null, null, "table%", Array("TABLE"))
       i = 0
-      while(rs4.next()) {
-        assert(rs4.getString(TABLE_NAME) == tables(i))
+      while(rs6.next()) {
+        assert(rs6.getString(TABLE_NAME) == tables(i))
         i += 1
       }
       assert(i === 2)
 
-      val rs5 = metaData.getTables(null, "default", "%", Array("VIEW"))
+      val rs7 = metaData.getTables(null, "default", "%", Array("VIEW"))
       i = 2
-      while(rs5.next()) {
-        assert(rs5.getString(TABLE_NAME) == view_test)
+      while(rs7.next()) {
+        assert(rs7.getString(TABLE_NAME) == view_test)
       }
-
-      val e = intercept[HiveSQLException](metaData.getTables(null, "*", null, null))
-      assert(e.getCause.getMessage contains "Dangling meta character '*' near index 0\n*\n^")
     }
   }
 

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/JDBCTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/JDBCTests.scala
@@ -106,7 +106,7 @@ trait JDBCTests extends KyuubiFunSuite {
       dbs.foreach(db => statement.execute(s"CREATE DATABASE IF NOT EXISTS $db"))
       val metaData = statement.getConnection.getMetaData
 
-      Seq("", "%", null, ".*", "_*", "_%", ".%") foreach { pattern =>
+      Seq("", "*", "%", null, ".*", "_*", "_%", ".%") foreach { pattern =>
         checkResult(metaData.getSchemas(null, pattern), dbs ++ dbDflts)
       }
 
@@ -120,9 +120,6 @@ trait JDBCTests extends KyuubiFunSuite {
 
       checkResult(metaData.getSchemas(null, "db1"), Seq("db1"))
       checkResult(metaData.getSchemas(null, "db_not_exist"), Seq.empty)
-
-      val e = intercept[HiveSQLException](metaData.getSchemas(null, "*"))
-      assert(e.getCause.getMessage contains "Dangling meta character '*' near index 0\n*\n^")
     }
   }
 


### PR DESCRIPTION
![pan3793](https://badgen.net/badge/Hello/pan3793/green) [![PR 292](https://badgen.net/badge/Preview/PR%20292/blue)](https://github.com/yaooqinn/kyuubi/pull/292) ![Bug](https://badgen.net/badge/Label/Bug/) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=yaooqinn&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
-->

### Please add issue ID here?
<!-- replace ${issue ID} with the actual issue id -->
Fixes #280

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the user case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Before this PR, Kyuubi treat Operation GET_SCHEMAS * as an invalid Operation then cause HUE list databases failed, but HiveServer2 will return all databases on same request.

### Test Plan:
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible
- [x] Add screenshots for manual tests if appropriate
- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request

After PR:
![201610862635_ pic](https://user-images.githubusercontent.com/26535726/104832256-032fc600-58cb-11eb-839b-6ece5328245a.jpg)