### PR TITLE
Remove dulicated error msg for open sessions at engine side

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSQLSessionManager.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSQLSessionManager.scala
@@ -71,7 +71,7 @@ class SparkSQLSessionManager private (name: String, spark: SparkSession)
     } catch {
       case e: Exception =>
         sessionImpl.close()
-        throw KyuubiSQLException(s"Error opening session $handle for $user: ${e.getMessage}", e)
+        throw KyuubiSQLException(e)
     }
   }
 


### PR DESCRIPTION
![yaooqinn](https://badgen.net/badge/Hello/yaooqinn/green) [![PR 293](https://badgen.net/badge/Preview/PR%20293/blue)](https://github.com/yaooqinn/kyuubi/pull/293) ![Bug](https://badgen.net/badge/Label/Bug/) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=yaooqinn&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
-->

### Please add issue ID here?
<!-- replace ${issue ID} with the actual issue id -->
Fixes #293

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the user case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

the error shows 2 twice in one msg with different session IDs

### Test Plan:
- Add some test cases that check the changes thoroughly including negative and positive cases if possible
- Add screenshots for manual tests if appropriate
- [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request