### PR TITLE
Remove unused property from build properties file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,6 @@
 build/apache-maven*
 build/scala*
 build/test
-kyuubi-server/build
-kyuubi-server/*example*
 target/
 dist/
 kyuubi-*-bin-*
@@ -40,7 +38,6 @@ derby.log
 ldap
 */dependency-reduced-pom.xml
 */*/dependency-reduced-pom.xml
-kyuubi-server/kyuubi-kdc/
 metrics/report.json
 metrics/.report.json.crc
 /kyuubi-ha/embedded_zookeeper/

--- a/build/kyuubi-build-info
+++ b/build/kyuubi-build-info
@@ -29,7 +29,6 @@ echo_build_properties() {
   echo kyuubi_hive_version="$6"
   echo kyuubi_hadoop_version="$7"
   echo user="$USER"
-  echo jar=kyuubi-server-$2.jar
   echo revision=$(git rev-parse HEAD)
   echo branch=$(git rev-parse --abbrev-ref HEAD)
   echo date=$(date -u +%Y-%m-%dT%H:%M:%SZ)


### PR DESCRIPTION
![turboFei](https://badgen.net/badge/Hello/turboFei/green) [![PR 297](https://badgen.net/badge/Preview/PR%20297/blue)](https://github.com/yaooqinn/kyuubi/pull/297) ![Target Issue](https://badgen.net/badge/Missing/Target%20Issue/ff0000) ![Test Plan](https://badgen.net/badge/Missing/Test%20Plan/ff0000) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=yaooqinn&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Now, there is no module named `kyuubi-server`.
And the property `jar` written into kyuubi-version-info.properties is not correct, it is also not used in `package` object.

https://github.com/yaooqinn/kyuubi/blob/6f8564ce595740feef1c6a0da85c06cd331cd753/kyuubi-common/src/main/scala/org/apache/kyuubi/package.scala#L37-L50