### PR TITLE
Fix Kyuubi will wait until timeout even spark driver has shutdown in client mode

### DIFF
--- a/kyuubi-main/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
+++ b/kyuubi-main/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
@@ -56,7 +56,7 @@ trait ProcBuilder {
     pb
   }
 
-  @volatile private var error: Throwable = UNCAUGHT_ERROR
+  @volatile private var error: Option[Throwable] = None
   // Visible for test
   private[kyuubi] var logCaptureThread: Thread = null
 
@@ -82,7 +82,7 @@ trait ProcBuilder {
               line = reader.readLine()
             }
 
-            error = KyuubiSQLException(sb.toString())
+            error = Some(KyuubiSQLException(sb.toString()))
           }
           line = reader.readLine()
         }
@@ -106,10 +106,10 @@ trait ProcBuilder {
   }
 
   def getError: Throwable = synchronized {
-    if (error == UNCAUGHT_ERROR) {
+    if (error.isEmpty) {
       Thread.sleep(3000)
     }
-    error
+    error.getOrElse(UNCAUGHT_ERROR)
   }
 }
 

--- a/kyuubi-main/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-main/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -38,6 +38,10 @@ class SparkProcessBuilder(
 
   import SparkProcessBuilder._
 
+  val isClusterMode: Boolean = {
+    conf.get("spark.submit.deployMode").contains("cluster")
+  }
+
   override protected val processLogRetainTimeMillis: Long = {
     conf.get(s"spark.${SESSION_SUBMIT_LOG_RETAIN_MILLIS.key}").map(_.toLong)
       .getOrElse(Duration.ofDays(1).toMillis)

--- a/kyuubi-main/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-main/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -113,13 +113,9 @@ class KyuubiSessionImpl(
           val started = System.currentTimeMillis()
           // Here are 4 option:
           // 1. Spark exit error (exitValue != 0)
-          //    we need to throw exception.
           // 2. Client mode, Spark exit normally (exitValue = 0) but failed to get server host
-          //    we need to throw exception.
           // 3. timeout
-          //    we need to throw exception.
           // 4. We get server host successfully
-          //    we need to release the loop and go to next logic.
           while (sh.isEmpty) {
             if (process.waitFor(1, TimeUnit.SECONDS)) {
               if (process.exitValue() != 0) {
@@ -132,8 +128,8 @@ class KyuubiSessionImpl(
             }
             if (started + timeout <= System.currentTimeMillis()) {
               process.destroyForcibly()
-              throw KyuubiSQLException(
-                s"Timed out($timeout ms) to launched Spark with $builder", builder.getError)
+              throw KyuubiSQLException(s"Timed out($timeout ms) to launched Spark with $builder",
+                builder.getError)
             }
             sh = getServerHost
           }


### PR DESCRIPTION
![ulysses-you](https://badgen.net/badge/Hello/ulysses-you/green) [![PR 301](https://badgen.net/badge/Preview/PR%20301/blue)](https://github.com/yaooqinn/kyuubi/pull/301) ![Target Issue](https://badgen.net/badge/Missing/Target%20Issue/ff0000) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=yaooqinn&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
-->

### Please add issue ID here?
<!-- replace ${issue ID} with the actual issue id -->
Fixes [#264](https://github.com/yaooqinn/kyuubi/pull/264)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the user case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In client mode, Spark driver may be shutdown due to some problem, e.g., permission issue. The exit code will return 0 since the linux process exit normally. It's no meaning to wait until timeout if driver has already shutdown.

### Test Plan:
- Add some test cases that check the changes thoroughly including negative and positive cases if possible
- Add screenshots for manual tests if appropriate
- [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request