### PR TITLE
Add host:port msg if we failed to initialize

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/FrontendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/FrontendService.scala
@@ -99,8 +99,8 @@ class FrontendService private (name: String, be: BackendService, oomHook: Runnab
         s" [$minThreads, $maxThreads] worker threads")
     } catch {
       case e: Throwable =>
-        throw new KyuubiException("Failed to initialize frontend service, " +
-          s"please check this host:port $serverAddr:$portNum is available.", e)
+        throw new KyuubiException(
+          s"Failed to initialize frontend service on $serverAddr:$portNum.", e)
     }
     super.initialize(conf)
   }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/FrontendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/FrontendService.scala
@@ -99,7 +99,8 @@ class FrontendService private (name: String, be: BackendService, oomHook: Runnab
         s" [$minThreads, $maxThreads] worker threads")
     } catch {
       case e: Throwable =>
-        throw new KyuubiException("Failed to initialize frontend service", e)
+        throw new KyuubiException("Failed to initialize frontend service, " +
+          s"please check this host:port $serverAddr:$portNum is available.", e)
     }
     super.initialize(conf)
   }


### PR DESCRIPTION
![ulysses-you](https://badgen.net/badge/Hello/ulysses-you/green) [![PR 303](https://badgen.net/badge/Preview/PR%20303/blue)](https://github.com/yaooqinn/kyuubi/pull/303) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=yaooqinn&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
-->

### Please add issue ID here?
<!-- replace ${issue ID} with the actual issue id -->
Fixes #303

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the user case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Before this PR, if we start Kyuubi with an already used port, we will get this error msg.
It's better to print host:port which we bind.
```
Exception in thread "main" org.apache.kyuubi.KyuubiException: Failed to initialize frontend service
	at org.apache.kyuubi.service.FrontendService.initialize(FrontendService.scala:102)
	at org.apache.kyuubi.service.CompositeService.$anonfun$initialize$1(CompositeService.scala:40)
	at org.apache.kyuubi.service.CompositeService.$anonfun$initialize$1$adapted(CompositeService.scala:40)
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
	at org.apache.kyuubi.service.CompositeService.initialize(CompositeService.scala:40)
	at org.apache.kyuubi.service.Serverable.initialize(Serverable.scala:37)
	at org.apache.kyuubi.server.KyuubiServer.initialize(KyuubiServer.scala:88)
	at org.apache.kyuubi.server.KyuubiServer$.startServer(KyuubiServer.scala:45)
	at org.apache.kyuubi.server.KyuubiServer$.main(KyuubiServer.scala:74)
	at org.apache.kyuubi.server.KyuubiServer.main(KyuubiServer.scala)
Caused by: java.net.BindException: Address already in use
	at java.net.PlainSocketImpl.socketBind(Native Method)
	at java.net.AbstractPlainSocketImpl.bind(AbstractPlainSocketImpl.java:387)
	at java.net.ServerSocket.bind(ServerSocket.java:375)
	at java.net.ServerSocket.<init>(ServerSocket.java:237)
	at org.apache.kyuubi.service.FrontendService.initialize(FrontendService.scala:77)
	... 11 more
```

### Test Plan:
- Add some test cases that check the changes thoroughly including negative and positive cases if possible
- Add screenshots for manual tests if appropriate
- [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request