### PR TITLE
[FOLLOWUP]GetSchemas supports DSv2 multipart namespaces with dot backtick

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/shim/Shim_v3_0.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/shim/Shim_v3_0.scala
@@ -62,7 +62,7 @@ class Shim_v3_0 extends Shim_v2_4 {
       catalog.listNamespaces(ns)
     }
     if (children.isEmpty) {
-      namespaces
+      namespaces.map(_.map(quoteIfNeeded))
     } else {
       namespaces.map(_.map(quoteIfNeeded)) ++: listNamespaces(catalog, children)
     }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/shim/Shim_v3_0.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/shim/Shim_v3_0.scala
@@ -64,7 +64,18 @@ class Shim_v3_0 extends Shim_v2_4 {
     if (children.isEmpty) {
       namespaces
     } else {
-      namespaces ++: listNamespaces(catalog, children)
+      namespaces.map(_.map(quoteIfNeeded)) ++: listNamespaces(catalog, children)
+    }
+  }
+
+  /**
+   * Forked from Apache Spark's org.apache.spark.sql.connector.catalog.CatalogV2Implicits
+   */
+  private def quoteIfNeeded(part: String): String = {
+    if (part.contains(".") || part.contains("`")) {
+      s"`${part.replace("`", "``")}`"
+    } else {
+      part
     }
   }
 

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/BasicIcebergJDBCTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/BasicIcebergJDBCTests.scala
@@ -92,13 +92,7 @@ trait BasicIcebergJDBCTests extends JDBCTestUtils {
 
   test("get schemas with multipart namespaces") {
     val dbs = Seq(
-      "`a.b`",
-      "`a.b`.c",
-      "a.`b.c`",
-      "`a.b.c`",
-      "`a.b``.c`",
-      "db1.db2.db3",
-      "db4")
+      "`a.b`")
 
     withDatabases(dbs: _*) { statement =>
       dbs.foreach(db => statement.execute(s"CREATE NAMESPACE IF NOT EXISTS $db"))

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/BasicIcebergJDBCTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/BasicIcebergJDBCTests.scala
@@ -92,7 +92,13 @@ trait BasicIcebergJDBCTests extends JDBCTestUtils {
 
   test("get schemas with multipart namespaces") {
     val dbs = Seq(
-      "`a.b`")
+      "`a.b`",
+      "`a.b`.c",
+      "a.`b.c`",
+      "`a.b.c`",
+      "`a.b``.c`",
+      "db1.db2.db3",
+      "db4")
 
     withDatabases(dbs: _*) { statement =>
       dbs.foreach(db => statement.execute(s"CREATE NAMESPACE IF NOT EXISTS $db"))

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/BasicIcebergJDBCTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/BasicIcebergJDBCTests.scala
@@ -91,7 +91,14 @@ trait BasicIcebergJDBCTests extends JDBCTestUtils {
   }
 
   test("get schemas with multipart namespaces") {
-    val dbs = Seq("db1", "db1.db2", "db1.db2.db3", "db4")
+    val dbs = Seq(
+      "`a.b`",
+      "`a.b`.c",
+      "a.`b.c`",
+      "`a.b.c`",
+      "`a.b``.c`",
+      "db1.db2.db3",
+      "db4")
 
     withDatabases(dbs: _*) { statement =>
       dbs.foreach(db => statement.execute(s"CREATE NAMESPACE IF NOT EXISTS $db"))
@@ -100,8 +107,8 @@ trait BasicIcebergJDBCTests extends JDBCTestUtils {
       val allPattern = Seq("", "*", "%", null, ".*", "_*", "_%", ".%")
       Seq(null, catalog).foreach { cg =>
         allPattern foreach { pattern =>
-          checkGetSchemas(
-            metaData.getSchemas(cg, pattern), dbs ++ Seq("global_temp"), catalog)
+          checkGetSchemas(metaData.getSchemas(cg, pattern),
+            dbs ++ Seq("global_temp", "a", "db1", "db1.db2"), catalog)
         }
       }
 


### PR DESCRIPTION
![yaooqinn](https://badgen.net/badge/Hello/yaooqinn/green) [![Closes #337](https://badgen.net/badge/Preview/Closes%20%23337/blue)](https://github.com/yaooqinn/kyuubi/pull/337) ![23](https://badgen.net/badge/%2B/23/red) ![5](https://badgen.net/badge/-/5/green) ![3](https://badgen.net/badge/commits/3/yellow) ![Target Issue](https://badgen.net/badge/Missing/Target%20Issue/ff0000) ![Bug](https://badgen.net/badge/Label/Bug/) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=yaooqinn&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/yaooqinn/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

add support for '.' and '`' in a namespace part

for instance, cases like https://github.com/yaooqinn/kyuubi/pull/337/files#diff-bcd0dfb958c3943a58a9705ac7053374c796449fefd6be7e9f014f9dd14b558fR94 produce the below catalog tree, we should treat `a.b`.c and a.`b.c` differently.
```
/var/folders/01/h81cs4sn3dq2dd_k4j6fhrmc0000gn/T/kyuubi-94c946f7-a64b-4980-9dd1-a63a573244dd
├── a
│   └── b.c
├── a.b
│   └── c
├── a.b.c
├── a.b`.c
├── db1
│   └── db2
│       └── db3
└── db4
```
### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request