### PR TITLE
[KYUUBI #347]Closing expired operations does not require updating 'lastAccessTime'

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
@@ -211,7 +211,7 @@ abstract class AbstractSession(
     }
   }
 
-  override def closeExpiredOperations: Unit = withAcquireRelease() {
+  override def closeExpiredOperations: Unit = {
     val operations = sessionManager.operationManager
       .removeExpiredOperations(opHandleSet.asScala.toSeq)
     operations.foreach { op =>


### PR DESCRIPTION
![Honglun](https://badgen.net/badge/Hello/Honglun/green) [![Closes #348](https://badgen.net/badge/Preview/Closes%20%23348/blue)](https://github.com/yaooqinn/kyuubi/pull/348) ![5](https://badgen.net/badge/%2B/5/red) ![4](https://badgen.net/badge/-/4/green) ![2](https://badgen.net/badge/commits/2/yellow) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=yaooqinn&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

… and 'lastTidleTime'

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/yaooqinn/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Method 'session.closeExpiredOperations' will constantly update the values of '_lastAccessTime' and '_lastIdleTime', so the session can't be closed. Method 'closeExpiredOperations' should remove 'withAcquirerease'.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request
conf.set(KyuubiConf.SESSION_CHECK_INTERVAL,Duration.ofSeconds(5).toMillis)
conf.set(KyuubiConf.SESSION_TIMEOUT,Duration.ofMinutes(1L).toMillis)
![image](https://user-images.githubusercontent.com/3722800/106875807-0cfe5980-6712-11eb-8a2e-d899d9c96bc1.png)