### PR TITLE
Avoid creating useless operation log for meta operation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,4 +70,4 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 after_failure:
-  - for log in `find * -name "unit-tests.log"`; do echo "=========$log========="; cat $log; done
+  - for log in `find * -name "kyuubi-spark-sql-engine.log*"`; do echo "=========$log========="; cat $log; done

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -36,6 +36,9 @@ class ExecuteStatement(
     override val shouldRunAsync: Boolean)
   extends SparkOperation(spark, OperationType.EXECUTE_STATEMENT, session) with Logging {
 
+  private val operationLog: OperationLog =
+    OperationLog.createOperationLog(session.handle, getHandle)
+  override def getOperationLog: Option[OperationLog] = Option(operationLog)
   private var result: DataFrame = _
 
   override protected def resultSchema: StructType = {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -39,10 +39,6 @@ abstract class SparkOperation(spark: SparkSession, opType: OperationType, sessio
 
   protected var iter: FetchIterator[Row] = _
 
-  protected final val operationLog: OperationLog =
-    OperationLog.createOperationLog(session.handle, getHandle)
-  override def getOperationLog: Option[OperationLog] = Option(operationLog)
-
   protected def resultSchema: StructType
 
   protected def cleanup(targetState: OperationState): Unit = synchronized {
@@ -104,7 +100,6 @@ abstract class SparkOperation(spark: SparkSession, opType: OperationType, sessio
     Thread.currentThread().setContextClassLoader(spark.sharedState.jarClassLoader)
     setHasResultSet(true)
     setState(OperationState.RUNNING)
-    OperationLog.setCurrentOperationLog(operationLog)
   }
 
   override protected def afterRun(): Unit = {

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -26,6 +26,7 @@ import org.apache.kyuubi.{KyuubiSQLException, Logging}
 import org.apache.kyuubi.config.KyuubiConf.OPERATION_IDLE_TIMEOUT
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
 import org.apache.kyuubi.operation.OperationType.OperationType
+import org.apache.kyuubi.operation.log.OperationLog
 import org.apache.kyuubi.session.Session
 
 abstract class AbstractOperation(opType: OperationType, session: Session)
@@ -38,6 +39,8 @@ abstract class AbstractOperation(opType: OperationType, session: Session)
     .map(_.toLong).getOrElse(Duration.ofHours(3).toMillis)
 
   protected final val statementId = handle.identifier.toString
+
+  override def getOperationLog: Option[OperationLog] = None
 
   @volatile protected var state: OperationState = INITIALIZED
   @volatile protected var startTime: Long = _

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/Operation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/Operation.scala
@@ -19,9 +19,8 @@ package org.apache.kyuubi.operation
 
 import java.util.concurrent.Future
 
-import org.apache.hive.service.rpc.thrift.{TProtocolVersion, TRowSet, TStatus, TStatusCode, TTableSchema}
+import org.apache.hive.service.rpc.thrift.{TProtocolVersion, TRowSet, TTableSchema}
 
-import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
 import org.apache.kyuubi.operation.log.OperationLog
 import org.apache.kyuubi.session.Session

--- a/kyuubi-main/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
+++ b/kyuubi-main/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
@@ -22,7 +22,6 @@ import org.apache.hive.service.rpc.thrift._
 import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
 import org.apache.kyuubi.operation.OperationType.OperationType
-import org.apache.kyuubi.operation.log.OperationLog
 import org.apache.kyuubi.session.Session
 import org.apache.kyuubi.util.ThriftUtils
 
@@ -39,8 +38,6 @@ abstract class KyuubiOperation(
   protected def verifyTStatus(tStatus: TStatus): Unit = {
     ThriftUtils.verifyTStatus(tStatus)
   }
-
-  override def getOperationLog: Option[OperationLog] = None
 
   protected def onError(action: String = "operating"): PartialFunction[Throwable, Unit] = {
     case e: Throwable =>


### PR DESCRIPTION
![yaooqinn](https://badgen.net/badge/Hello/yaooqinn/green) [![Closes #371](https://badgen.net/badge/Preview/Closes%20%23371/blue)](https://github.com/yaooqinn/kyuubi/pull/371) ![8](https://badgen.net/badge/%2B/8/red) ![11](https://badgen.net/badge/-/11/green) ![1](https://badgen.net/badge/commits/1/yellow) ![Target Issue](https://badgen.net/badge/Missing/Target%20Issue/ff0000) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=yaooqinn&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/yaooqinn/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_

1. Operation log for metadata is useless for client-side
2. Operation log for metadata dumps nothing useful for the engine side too
3. Operation log will create files that bring overhead for meta operations and may fail operations


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request