### PR TITLE
[KYUUBI #386] Clean up discovery service before engine stop in connection share level

### DIFF
--- a/externals/kyuubi-spark-sql-engine/pom.xml
+++ b/externals/kyuubi-spark-sql-engine/pom.xml
@@ -90,6 +90,12 @@
             <artifactId>${iceberg.name}</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -34,7 +34,6 @@ import org.apache.kyuubi.ha.client.{RetryPolicies, ServiceDiscovery}
 import org.apache.kyuubi.service.Serverable
 import org.apache.kyuubi.util.SignalRegister
 
-
 private[spark] final class SparkSQLEngine(name: String, spark: SparkSession)
   extends Serverable(name) {
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -31,7 +31,7 @@ import org.apache.kyuubi.config.KyuubiConf.ENGINE_SHARED_LEVEL
 import org.apache.kyuubi.engine.spark.SparkSQLEngine.countDownLatch
 import org.apache.kyuubi.ha.HighAvailabilityConf._
 import org.apache.kyuubi.ha.client.{RetryPolicies, ServiceDiscovery}
-import org.apache.kyuubi.service.Serverable
+import org.apache.kyuubi.service.{Serverable, ServiceState}
 import org.apache.kyuubi.util.SignalRegister
 
 private[spark] final class SparkSQLEngine(name: String, spark: SparkSession)
@@ -60,6 +60,9 @@ private[spark] final class SparkSQLEngine(name: String, spark: SparkSession)
   }
 
   override def stop(): Unit = {
+    if (getServiceState == ServiceState.STOPPED) {
+      return
+    }
     try {
       conf.get(ENGINE_SHARED_LEVEL) match {
         case "CONNECTION" =>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -63,19 +63,13 @@ private[spark] final class SparkSQLEngine(name: String, spark: SparkSession)
     if (getServiceState == ServiceState.STOPPED) {
       return
     }
-    try {
-      conf.get(ENGINE_SHARED_LEVEL) match {
-        case "CONNECTION" =>
-          info("Clean up discovery service due to this is connection share level.")
-          discoveryService.cleanup()
-        case _ =>
-      }
-    } catch {
-      case NonFatal(e) =>
-        warn("Failed to clean up Spark engine before stop.", e)
-    } finally {
-      super.stop()
+    conf.get(ENGINE_SHARED_LEVEL) match {
+      case "CONNECTION" =>
+        info("Clean up discovery service due to this is connection share level.")
+        discoveryService.cleanup()
+      case _ =>
     }
+    super.stop()
   }
 
   override protected def stopServer(): Unit = {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -25,11 +25,10 @@ import org.apache.spark.sql.SparkSession
 
 import org.apache.kyuubi.{Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.config.KyuubiConf.ENGINE_SHARED_LEVEL
 import org.apache.kyuubi.engine.spark.SparkSQLEngine.countDownLatch
 import org.apache.kyuubi.ha.HighAvailabilityConf._
 import org.apache.kyuubi.ha.client.{EngineServiceDiscovery, RetryPolicies, ServiceDiscovery}
-import org.apache.kyuubi.service.{Serverable, ServiceState}
+import org.apache.kyuubi.service.Serverable
 import org.apache.kyuubi.util.SignalRegister
 
 private[spark] final class SparkSQLEngine(name: String, spark: SparkSession)
@@ -55,16 +54,6 @@ private[spark] final class SparkSQLEngine(name: String, spark: SparkSession)
     // Start engine self-terminating checker after all services are ready and it can be reached by
     // all servers in engine spaces.
     backendService.sessionManager.startTerminatingChecker()
-  }
-
-  override def stop(): Unit = {
-    conf.get(ENGINE_SHARED_LEVEL) match {
-      case "CONNECTION" =>
-        info("Clean up discovery service due to this is connection share level.")
-        discoveryService.cleanup()
-      case _ =>
-    }
-    super.stop()
   }
 
   override protected def stopServer(): Unit = {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -20,8 +20,11 @@ package org.apache.kyuubi.engine.spark
 import java.time.Instant
 import java.util.concurrent.CountDownLatch
 
+import scala.util.control.NonFatal
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
+
 import org.apache.kyuubi.{Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.ENGINE_SHARED_LEVEL
@@ -31,7 +34,6 @@ import org.apache.kyuubi.ha.client.{RetryPolicies, ServiceDiscovery}
 import org.apache.kyuubi.service.Serverable
 import org.apache.kyuubi.util.SignalRegister
 
-import scala.util.control.NonFatal
 
 private[spark] final class SparkSQLEngine(name: String, spark: SparkSession)
   extends Serverable(name) {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -22,7 +22,6 @@ import java.util.concurrent.CountDownLatch
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
-
 import org.apache.kyuubi.{Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.ENGINE_SHARED_LEVEL
@@ -31,6 +30,8 @@ import org.apache.kyuubi.ha.HighAvailabilityConf._
 import org.apache.kyuubi.ha.client.{RetryPolicies, ServiceDiscovery}
 import org.apache.kyuubi.service.Serverable
 import org.apache.kyuubi.util.SignalRegister
+
+import scala.util.control.NonFatal
 
 private[spark] final class SparkSQLEngine(name: String, spark: SparkSession)
   extends Serverable(name) {
@@ -66,7 +67,7 @@ private[spark] final class SparkSQLEngine(name: String, spark: SparkSession)
         case _ =>
       }
     } catch {
-      case e: Throwable =>
+      case NonFatal(e) =>
         warn("Failed to clean up Spark engine before stop.", e)
     } finally {
       super.stop()

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
@@ -49,14 +49,15 @@ abstract class ShareLevelSparkEngineSuite
       assert(engine.getServiceState == ServiceState.STARTED)
       assert(zkClient.checkExists().forPath(namespace) != null)
       withJdbcStatement() {_ => }
-      eventually(Timeout(120.seconds)) {
-        assert(engine.getServiceState == ServiceState.STOPPED)
-      }
       sharedLevel match {
         // Connection level, we will cleanup namespace since it's always a global unique value.
         case ShareLevel.CONNECTION =>
+          eventually(Timeout(120.seconds)) {
+            assert(engine.getServiceState == ServiceState.STOPPED)
+          }
           assert(zkClient.checkExists().forPath(namespace) == null)
         case _ =>
+          assert(engine.getServiceState == ServiceState.STARTED)
           assert(zkClient.checkExists().forPath(namespace) != null)
       }
     }

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
@@ -54,8 +54,8 @@ abstract class ShareLevelSparkEngineSuite
         case ShareLevel.CONNECTION =>
           eventually(Timeout(120.seconds)) {
             assert(engine.getServiceState == ServiceState.STOPPED)
+            assert(zkClient.checkExists().forPath(namespace) == null)
           }
-          assert(zkClient.checkExists().forPath(namespace) == null)
         case _ =>
           assert(engine.getServiceState == ServiceState.STARTED)
           assert(zkClient.checkExists().forPath(namespace) != null)

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
@@ -71,11 +71,3 @@ class ConnectionLevelSparkEngineSuite extends ShareLevelSparkEngineSuite {
 class UserLevelSparkEngineSuite extends ShareLevelSparkEngineSuite {
   override def sharedLevel: ShareLevel = ShareLevel.USER
 }
-
-class GroupLevelSparkEngineSuite extends ShareLevelSparkEngineSuite {
-  override def sharedLevel: ShareLevel = ShareLevel.GROUP
-}
-
-class ServerLevelSparkEngineSuite extends ShareLevelSparkEngineSuite {
-  override def sharedLevel: ShareLevel = ShareLevel.SERVER
-}

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
@@ -31,8 +31,8 @@ import org.apache.kyuubi.operation.JDBCTestUtils
 abstract class ShareLevelSparkEngineSuite
   extends WithDiscoverySparkSQLEngine with JDBCTestUtils {
   def sharedLevel: ShareLevel
-  override def conf: Map[String, String] = {
-    Map(ENGINE_SHARED_LEVEL.key-> sharedLevel.toString)
+  override def withKyuubiConf: Map[String, String] = {
+    super.withKyuubiConf ++ Map(ENGINE_SHARED_LEVEL.key-> sharedLevel.toString)
   }
   override protected def jdbcUrl: String = getJdbcUrl
   override val namespace: String = {

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
@@ -46,6 +46,7 @@ abstract class ShareLevelSparkEngineSuite
 
   test("check discovery service is clean up with different share level") {
     withZkClient { zkClient =>
+      assert(engine.getServiceState == ServiceState.STARTED)
       assert(zkClient.checkExists().forPath(namespace) != null)
       withJdbcStatement() {_ => }
       eventually(Timeout(120.seconds)) {

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
@@ -54,8 +54,8 @@ abstract class ShareLevelSparkEngineSuite
         case ShareLevel.CONNECTION =>
           eventually(Timeout(120.seconds)) {
             assert(engine.getServiceState == ServiceState.STOPPED)
-            assert(zkClient.checkExists().forPath(namespace) == null)
           }
+          assert(zkClient.checkExists().forPath(namespace) == null)
         case _ =>
           assert(engine.getServiceState == ServiceState.STARTED)
           assert(zkClient.checkExists().forPath(namespace) != null)

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.engine.spark
+
+import java.util.UUID
+
+import org.apache.kyuubi.config.KyuubiConf.ENGINE_SHARED_LEVEL
+import org.apache.kyuubi.engine.ShareLevel
+import org.apache.kyuubi.engine.ShareLevel.ShareLevel
+import org.apache.kyuubi.operation.JDBCTestUtils
+
+/**
+ * This suite is to test some behaivor with spark engine in different share level.
+ * e.g. cleanup discovery service before stop.
+ */
+abstract class ShareLevelSparkEngineSuite
+  extends WithDiscoverySparkSQLEngine with JDBCTestUtils {
+  def sharedLevel: ShareLevel
+  override def conf: Map[String, String] = {
+    Map(ENGINE_SHARED_LEVEL.key-> sharedLevel.toString)
+  }
+  override protected def jdbcUrl: String = getJdbcUrl
+  override val namespace: String = {
+    // for test, we always use uuid as namespace
+    s"/kyuubi/${sharedLevel.toString}/${UUID.randomUUID().toString}"
+  }
+
+  test("check discovery service is clean up with different share level") {
+    withZkClient { zkClient =>
+      assert(zkClient.checkExists().forPath(namespace) != null)
+      withJdbcStatement() {_ => }
+      sharedLevel match {
+        // Connection level, we will cleanup namespace since it's always a global unique value.
+        case ShareLevel.CONNECTION =>
+          assert(zkClient.checkExists().forPath(namespace) == null)
+        case _ =>
+          assert(zkClient.checkExists().forPath(namespace) != null)
+      }
+    }
+  }
+}
+
+class ConnectionLevelSparkEngineSuite extends ShareLevelSparkEngineSuite {
+  override def sharedLevel: ShareLevel = ShareLevel.CONNECTION
+}
+
+class UserLevelSparkEngineSuite extends ShareLevelSparkEngineSuite {
+  override def sharedLevel: ShareLevel = ShareLevel.USER
+}
+
+class GroupLevelSparkEngineSuite extends ShareLevelSparkEngineSuite {
+  override def sharedLevel: ShareLevel = ShareLevel.GROUP
+}
+
+class ServerLevelSparkEngineSuite extends ShareLevelSparkEngineSuite {
+  override def sharedLevel: ShareLevel = ShareLevel.SERVER
+}

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
@@ -52,9 +52,7 @@ abstract class ShareLevelSparkEngineSuite
       sharedLevel match {
         // Connection level, we will cleanup namespace since it's always a global unique value.
         case ShareLevel.CONNECTION =>
-          eventually(Timeout(120.seconds)) {
-            assert(engine.getServiceState == ServiceState.STOPPED)
-          }
+          assert(engine.getServiceState == ServiceState.STOPPED)
           assert(zkClient.checkExists().forPath(namespace) == null)
         case _ =>
           assert(engine.getServiceState == ServiceState.STARTED)

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ShareLevelSparkEngineSuite.scala
@@ -19,10 +19,14 @@ package org.apache.kyuubi.engine.spark
 
 import java.util.UUID
 
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+
 import org.apache.kyuubi.config.KyuubiConf.ENGINE_SHARED_LEVEL
 import org.apache.kyuubi.engine.ShareLevel
 import org.apache.kyuubi.engine.ShareLevel.ShareLevel
 import org.apache.kyuubi.operation.JDBCTestUtils
+import org.apache.kyuubi.service.ServiceState
 
 /**
  * This suite is to test some behaivor with spark engine in different share level.
@@ -44,6 +48,9 @@ abstract class ShareLevelSparkEngineSuite
     withZkClient { zkClient =>
       assert(zkClient.checkExists().forPath(namespace) != null)
       withJdbcStatement() {_ => }
+      eventually(Timeout(120.seconds)) {
+        assert(engine.getServiceState == ServiceState.STOPPED)
+      }
       sharedLevel match {
         // Connection level, we will cleanup namespace since it's always a global unique value.
         case ShareLevel.CONNECTION =>

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/SparkSQLEngineListenerSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/SparkSQLEngineListenerSuite.scala
@@ -20,7 +20,7 @@ package org.apache.kyuubi.engine.spark
 import org.apache.kyuubi.service.ServiceState
 
 class SparkSQLEngineListenerSuite extends WithSparkSQLEngine {
-  override def conf: Map[String, String] = Map.empty
+  override def withKyuubiConf: Map[String, String] = Map.empty
 
   test("application end") {
     assert(engine.getServiceState === ServiceState.STARTED)

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/WithDiscoverySparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/WithDiscoverySparkSQLEngine.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.engine.spark
+
+import org.apache.curator.framework.CuratorFramework
+
+import org.apache.kyuubi.Utils
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.config.KyuubiConf.{EMBEDDED_ZK_PORT, EMBEDDED_ZK_TEMP_DIR}
+import org.apache.kyuubi.ha.HighAvailabilityConf.{HA_ZK_ACL_ENABLED, HA_ZK_NAMESPACE, HA_ZK_QUORUM}
+import org.apache.kyuubi.ha.client.ServiceDiscovery
+import org.apache.kyuubi.ha.server.EmbeddedZkServer
+
+trait WithDiscoverySparkSQLEngine extends WithSparkSQLEngine {
+  private var zkServer: EmbeddedZkServer = _
+  def kyuubiConf: KyuubiConf = SparkSQLEngine.kyuubiConf
+  def namespace: String
+
+  override protected def beforeEach(): Unit = {
+    zkServer = new EmbeddedZkServer()
+    val zkData = Utils.createTempDir()
+    kyuubiConf.set(EMBEDDED_ZK_PORT, -1)
+    kyuubiConf.set(EMBEDDED_ZK_TEMP_DIR, zkData.toString)
+    zkServer.initialize(kyuubiConf)
+    zkServer.start()
+    kyuubiConf.set(HA_ZK_QUORUM, zkServer.getConnectString)
+    kyuubiConf.set(HA_ZK_ACL_ENABLED, false)
+    kyuubiConf.set(HA_ZK_NAMESPACE, namespace)
+    super.beforeEach()
+    startSparkEngine()
+  }
+
+  override protected def afterEach(): Unit = {
+    super.afterEach()
+    stopSparkEngine()
+
+    if (zkServer != null) {
+      zkServer.stop()
+    }
+  }
+
+  def withZkClient(f: CuratorFramework => Unit): Unit = {
+    val zkClient = ServiceDiscovery.startZookeeperClient(kyuubiConf)
+    try {
+      f(zkClient)
+    } finally {
+      zkClient.close()
+    }
+  }
+
+  protected def getDiscoveryConnectionString: String = {
+    if (zkServer == null) {
+      ""
+    } else {
+      zkServer.getConnectString
+    }
+  }
+}

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/WithSparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/WithSparkSQLEngine.scala
@@ -59,15 +59,17 @@ trait WithSparkSQLEngine extends KyuubiFunSuite {
 
   override def afterAll(): Unit = {
     super.afterAll()
+
+    stopSparkEngine()
+  }
+
+  protected def stopSparkEngine(): Unit = {
     // we need to clean up conf since it's the global config in same jvm.
     withKyuubiConf.foreach { case (k, _) =>
       System.clearProperty(k)
       kyuubiConf.unset(k)
     }
-    stopSparkEngine()
-  }
 
-  protected def stopSparkEngine(): Unit = {
     if (engine != null) {
       engine.stop()
       engine = null

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/WithSparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/WithSparkSQLEngine.scala
@@ -20,11 +20,14 @@ package org.apache.kyuubi.engine.spark
 import org.apache.spark.sql.SparkSession
 
 import org.apache.kyuubi.{KyuubiFunSuite, Utils}
+import org.apache.kyuubi.config.KyuubiConf
 
 trait WithSparkSQLEngine extends KyuubiFunSuite {
   protected var spark: SparkSession = _
   protected var engine: SparkSQLEngine = _
-  def conf: Map[String, String]
+  // conf will be loaded until start spark engine
+  def withKyuubiConf: Map[String, String]
+  val kyuubiConf: KyuubiConf = SparkSQLEngine.kyuubiConf
 
   protected var connectionUrl: String = _
 
@@ -42,9 +45,9 @@ trait WithSparkSQLEngine extends KyuubiFunSuite {
       s"jdbc:derby:;databaseName=$metastorePath;create=true")
     System.setProperty("spark.sql.warehouse.dir", warehousePath.toString)
     System.setProperty("spark.sql.hive.metastore.sharedPrefixes", "org.apache.hive.jdbc")
-    conf.foreach { case (k, v) =>
+    withKyuubiConf.foreach { case (k, v) =>
       System.setProperty(k, v)
-      SparkSQLEngine.kyuubiConf.set(k, v)
+      kyuubiConf.set(k, v)
     }
 
     SparkSession.clearActiveSession()
@@ -56,6 +59,11 @@ trait WithSparkSQLEngine extends KyuubiFunSuite {
 
   override def afterAll(): Unit = {
     super.afterAll()
+    // we need to clean up conf since it's the global config in same jvm.
+    withKyuubiConf.foreach { case (k, _) =>
+      System.clearProperty(k)
+      kyuubiConf.unset(k)
+    }
     stopSparkEngine()
   }
 

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkIcebergOperationSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkIcebergOperationSuite.scala
@@ -22,7 +22,7 @@ import org.apache.kyuubi.operation.BasicIcebergJDBCTests
 
 class SparkIcebergOperationSuite extends WithSparkSQLEngine with BasicIcebergJDBCTests {
   override protected def jdbcUrl: String = getJdbcUrl
-  override def conf: Map[String, String] = icebergConfigs
+  override def withKyuubiConf: Map[String, String] = icebergConfigs
 
   override def afterAll(): Unit = {
     super.afterAll()

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
@@ -39,7 +39,7 @@ import org.apache.kyuubi.operation.meta.ResultSetSchemaConstant._
 class SparkOperationSuite extends WithSparkSQLEngine with JDBCTests {
 
   override protected def jdbcUrl: String = getJdbcUrl
-  override def conf: Map[String, String] = Map.empty
+  override def withKyuubiConf: Map[String, String] = Map.empty
 
   test("get table types") {
     withJdbcStatement() { statement =>

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/session/SessionSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/session/SessionSuite.scala
@@ -27,7 +27,7 @@ import org.apache.kyuubi.operation.JDBCTestUtils
 import org.apache.kyuubi.service.ServiceState._
 
 class SessionSuite extends WithSparkSQLEngine with JDBCTestUtils {
-  override def conf: Map[String, String] = {
+  override def withKyuubiConf: Map[String, String] = {
    Map(ENGINE_SHARED_LEVEL.key -> "CONNECTION")
   }
 

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/EngineServiceDiscovery.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/EngineServiceDiscovery.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ha.client
+
+import org.apache.kyuubi.service.Serverable
+
+/**
+ * A service for service discovery used by engine side.
+ *
+ * @param name the name of the service itself
+ * @param server the instance uri a service that used to publish itself
+ */
+class EngineServiceDiscovery private(
+    name: String,
+    server: Serverable) extends ServiceDiscovery(server) {
+  def this(server: Serverable) =
+    this(classOf[EngineServiceDiscovery].getSimpleName, server)
+
+}
+
+

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/EngineServiceDiscovery.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/EngineServiceDiscovery.scala
@@ -17,10 +17,10 @@
 
 package org.apache.kyuubi.ha.client
 
+import scala.util.control.NonFatal
+
 import org.apache.kyuubi.config.KyuubiConf.ENGINE_SHARED_LEVEL
 import org.apache.kyuubi.service.Serverable
-
-import scala.util.control.NonFatal
 
 /**
  * A service for service discovery used by engine side.

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/KyuubiServiceDiscovery.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/KyuubiServiceDiscovery.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ha.client
+
+import org.apache.zookeeper.{WatchedEvent, Watcher}
+
+import org.apache.kyuubi.KyuubiException
+import org.apache.kyuubi.service.Serverable
+
+/**
+ * A service for service discovery used by kyuubi server side.
+ * We add another zk watch so that we can stop server more genteelly.
+ *
+ * @param name the name of the service itself
+ * @param server the instance uri a service that used to publish itself
+ */
+class KyuubiServiceDiscovery private(
+    name: String,
+    server: Serverable) extends ServiceDiscovery(server) {
+  def this(server: Serverable) =
+    this(classOf[KyuubiServiceDiscovery].getSimpleName, server)
+
+  override def start(): Unit = {
+    super.start()
+    // Set a watch on the serviceNode
+    val watcher = new DeRegisterWatcher
+    if (zkClient.checkExists.usingWatcher(watcher).forPath(serviceNode.getActualPath) == null) {
+      // No node exists, throw exception
+      throw new KyuubiException(s"Unable to create znode for this Kyuubi " +
+        s"instance[${server.connectionUrl}] on ZooKeeper.")
+    }
+  }
+
+  override def stopGracefully(): Unit = {
+    stop()
+    while (server.backendService != null &&
+      server.backendService.sessionManager.getOpenSessionCount > 0) {
+      Thread.sleep(1000 * 60)
+    }
+    server.stop()
+  }
+
+  class DeRegisterWatcher extends Watcher {
+    override def process(event: WatchedEvent): Unit = {
+      if (event.getType == Watcher.Event.EventType.NodeDeleted) {
+        warn(s"This Kyuubi instance ${server.connectionUrl} is now de-registered from" +
+          s" ZooKeeper. The server will be shut down after the last client session completes.")
+        stopGracefully()
+      }
+    }
+  }
+}
+
+

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
@@ -162,19 +162,6 @@ abstract class ServiceDiscovery private (
     }
   }
 
-  // clean up the namespace in zk
-  def cleanup(): Unit = {
-    closeServiceNode()
-    if (namespace != null) {
-      try {
-        zkClient.delete().deletingChildrenIfNeeded().forPath(namespace)
-      } catch {
-        case NonFatal(e) =>
-          warn("Failed to clean up Spark engine before stop.", e)
-      }
-    }
-  }
-
   // stop the server genteelly
   def stopGracefully(): Unit = {
     stop()

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import javax.security.auth.login.Configuration
 
 import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
 
 import org.apache.curator.framework.{CuratorFramework, CuratorFrameworkFactory}
 import org.apache.curator.framework.recipes.nodes.PersistentEphemeralNode
@@ -168,7 +169,12 @@ class ServiceDiscovery private (
   def cleanup(): Unit = {
     closeServiceNode()
     if (namespace != null) {
-      zkClient.delete().deletingChildrenIfNeeded().forPath(namespace)
+      try {
+        zkClient.delete().deletingChildrenIfNeeded().forPath(namespace)
+      } catch {
+        case NonFatal(e) =>
+          warn("Failed to clean up Spark engine before stop.", e)
+      }
     }
   }
 

--- a/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/ServiceDiscoverySuite.scala
+++ b/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/ServiceDiscoverySuite.scala
@@ -66,7 +66,7 @@ class ServiceDiscoverySuite extends KerberizedTestHelper {
     server.start()
 
     val znodeRoot = s"/$namespace"
-    val serviceDiscovery = new ServiceDiscovery(server)
+    val serviceDiscovery = new KyuubiServiceDiscovery(server)
     val framework = ServiceDiscovery.startZookeeperClient(conf)
     try {
       serviceDiscovery.initialize(conf)

--- a/kyuubi-main/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
+++ b/kyuubi-main/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
@@ -24,7 +24,7 @@ import org.apache.hadoop.security.UserGroupInformation
 import org.apache.kyuubi._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.ha.HighAvailabilityConf._
-import org.apache.kyuubi.ha.client.ServiceDiscovery
+import org.apache.kyuubi.ha.client.{KyuubiServiceDiscovery, ServiceDiscovery}
 import org.apache.kyuubi.ha.server.EmbeddedZkServer
 import org.apache.kyuubi.service.{AbstractBackendService, KinitAuxiliaryService, Serverable}
 import org.apache.kyuubi.util.{KyuubiHadoopUtils, SignalRegister}
@@ -79,7 +79,7 @@ class KyuubiServer(name: String) extends Serverable(name) {
   def this() = this(classOf[KyuubiServer].getSimpleName)
 
   override private[kyuubi] val backendService: AbstractBackendService = new KyuubiBackendService()
-  private val discoveryService = new ServiceDiscovery(this)
+  private val discoveryService = new KyuubiServiceDiscovery(this)
 
   override def initialize(conf: KyuubiConf): Unit = synchronized {
     val kinit = new KinitAuxiliaryService()


### PR DESCRIPTION
![ulysses-you](https://badgen.net/badge/Hello/ulysses-you/green) [![Closes #387](https://badgen.net/badge/Preview/Closes%20%23387/blue)](https://github.com/yaooqinn/kyuubi/pull/387) ![330](https://badgen.net/badge/%2B/330/red) ![52](https://badgen.net/badge/-/52/green) ![18](https://badgen.net/badge/commits/18/yellow) ![Test Plan](https://badgen.net/badge/Missing/Test%20Plan/ff0000) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=yaooqinn&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/yaooqinn/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In connection level, we will release engine if the session connection is closed but we don't clean up the discovery service (i.e. the namespace in zookeeper). That may cause the disk stress after running a long time.


### _How was this patch tested?_
Add some new suites in spark engine moudle with zk emmbedded.