### PR TITLE
[BUILD] Downgrade scala-maven-plugin to 4.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
 
         <maven.plugin.antrun.version>3.0.0</maven.plugin.antrun.version>
         <maven.plugin.compiler.version>3.8.1</maven.plugin.compiler.version>
+        <!-- DO NOT bump 4.4.0, see https://github.com/yaooqinn/kyuubi/pull/441 -->
         <maven.plugin.scala.version>4.3.0</maven.plugin.scala.version>
         <maven.plugin.surefire.version>2.22.0</maven.plugin.surefire.version>
         <maven.plugin.scalatest.version>2.0.0</maven.plugin.scalatest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 
         <maven.plugin.antrun.version>3.0.0</maven.plugin.antrun.version>
         <maven.plugin.compiler.version>3.8.1</maven.plugin.compiler.version>
-        <maven.plugin.scala.version>4.4.0</maven.plugin.scala.version>
+        <maven.plugin.scala.version>4.3.0</maven.plugin.scala.version>
         <maven.plugin.surefire.version>2.22.0</maven.plugin.surefire.version>
         <maven.plugin.scalatest.version>2.0.0</maven.plugin.scalatest.version>
         <maven.plugin.scalatest.exclude.tags></maven.plugin.scalatest.exclude.tags>


### PR DESCRIPTION
![pan3793](https://badgen.net/badge/Hello/pan3793/green) [![Closes #441](https://badgen.net/badge/Preview/Closes%20%23441/blue)](https://github.com/yaooqinn/kyuubi/pull/441) ![2](https://badgen.net/badge/%2B/2/red) ![1](https://badgen.net/badge/-/1/green) ![2](https://badgen.net/badge/commits/2/yellow) ![Target Issue](https://badgen.net/badge/Missing/Target%20Issue/ff0000) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=yaooqinn&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/yaooqinn/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
There are several known issues with `scala-maven-plugin:4.4.0` about `zinc`.

On CentOS 7, with Oracle JDK 8 installed via RPM, `/bin/java` links to `jdk/jre/bin/java` but `/bin/javac` links to `jdk/bin/javac`
```
[ops@bd-ck-uat-30007-vm ~]$ ll -l /bin/java
lrwxrwxrwx 1 root root 22 Mar 12 14:03 /bin/java -> /etc/alternatives/java
[ops@bd-ck-uat-30007-vm ~]$ ll -l /etc/alternatives/java
lrwxrwxrwx 1 root root 41 Mar 12 14:03 /etc/alternatives/java -> /usr/java/jdk1.8.0_251-amd64/jre/bin/java
[ops@bd-ck-uat-30007-vm ~]$ ll -l /bin/javac
lrwxrwxrwx 1 root root 23 Mar 12 14:03 /bin/javac -> /etc/alternatives/javac
[ops@bd-ck-uat-30007-vm ~]$ ll -l /etc/alternatives/javac
lrwxrwxrwx 1 root root 38 Mar 12 14:03 /etc/alternatives/javac -> /usr/java/jdk1.8.0_251-amd64/bin/javac
```
when run `build/dist --tgz` cause
```
[ERROR] Failed to execute goal net.alchim31.maven:scala-maven-plugin:4.4.0:testCompile (scala-test-compile-first) on project kyuubi-common: wrap: java.io.IOException: Cannot run program "/usr/java/jdk1.8.0_221-amd64/jre/bin/javac" (in directory "/data/ansible/ci/kyuubi"): error=2, No such file or directory -> [Help 1]
```
And there is another issue reported by Apache Spark: https://github.com/apache/spark/pull/31031

Please also merge it into branch-1.1

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request