### PR TITLE
[KYUUBI #457] Support configurable initialize sql statement for engine startup

### DIFF
--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -133,6 +133,13 @@ kyuubi\.delegation<br>\.token\.max\.lifetime|<div style='width: 65pt;word-wrap: 
 kyuubi\.delegation<br>\.token\.renew\.interval|<div style='width: 65pt;word-wrap: break-word;white-space: normal'>PT168H</div>|<div style='width: 170pt;word-wrap: break-word;white-space: normal'>unused yet</div>|<div style='width: 30pt'>duration</div>|<div style='width: 20pt'>1.0.0</div>
 
 
+### Engine
+
+Key | Default | Meaning | Type | Since
+--- | --- | --- | --- | ---
+kyuubi\.engine<br>\.initialize\.sql|<div style='width: 65pt;word-wrap: break-word;white-space: normal'>SHOW DATABASES</div>|<div style='width: 170pt;word-wrap: break-word;white-space: normal'>SemiColon-separated list of SQL statements to be initialized in the newly created engine before queries.</div>|<div style='width: 30pt'>string</div>|<div style='width: 20pt'>1.2.0</div>
+
+
 ### Frontend
 
 Key | Default | Meaning | Type | Since

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -96,7 +96,7 @@ object SparkSQLEngine extends Logging {
     }
 
     val session = SparkSession.builder().config(sparkConf).enableHiveSupport().getOrCreate()
-    session.sql("SHOW DATABASES")
+    kyuubiConf.get(KyuubiConf.ENGINE_INITIALIZE_SQL).split(";").foreach(session.sql(_).show)
     session
   }
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -522,4 +522,15 @@ object KyuubiConf {
     .transform(_.toUpperCase(Locale.ROOT))
     .checkValues(ShareLevel.values.map(_.toString))
     .createWithDefault(ShareLevel.USER.toString)
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////
+  //                                   Engine Configuration                                      //
+  /////////////////////////////////////////////////////////////////////////////////////////////////
+
+  val ENGINE_INITIALIZE_SQL: ConfigEntry[String] = buildConf("engine.initialize.sql")
+    .doc("SemiColon-separated list of SQL statements to be initialized in the newly created " +
+      "engine before queries.")
+    .version("1.2.0")
+    .stringConf
+    .createWithDefault("SHOW DATABASES")
 }

--- a/kyuubi-main/src/test/scala/org/apache/kyuubi/engine/spark/SparkSqlEngineSuite.scala
+++ b/kyuubi-main/src/test/scala/org/apache/kyuubi/engine/spark/SparkSqlEngineSuite.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.engine.spark
+
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.config.KyuubiConf.ENGINE_INITIALIZE_SQL
+import org.apache.kyuubi.operation.{JDBCTestUtils, WithKyuubiServer}
+
+class SparkSqlEngineSuite extends WithKyuubiServer with JDBCTestUtils  {
+  override protected val conf: KyuubiConf = {
+    KyuubiConf().set(ENGINE_INITIALIZE_SQL.key,
+      "CREATE DATABASE IF NOT EXISTS INIT_DB;" +
+        "CREATE TABLE IF NOT EXISTS INIT_DB.test(a int);" +
+        "INSERT OVERWRITE TABLE INIT_DB.test SELECT 1;")
+  }
+
+  override def afterAll(): Unit = {
+    withJdbcStatement() { statement =>
+      statement.executeQuery("DROP TABLE IF EXISTS INIT_DB.test")
+      statement.executeQuery("DROP DATABASE IF EXISTS INIT_DB")
+    }
+    super.afterAll()
+  }
+
+  test("KYUUBI-457: Support configurable initialize sql statement for engine startup") {
+    withJdbcStatement() { statement =>
+      val result = statement.executeQuery("SELECT * FROM INIT_DB.test")
+      assert(result.next())
+      assert(result.getInt(1) == 1)
+      assert(!result.next())
+    }
+  }
+
+  override protected def jdbcUrl: String = getJdbcUrl
+}


### PR DESCRIPTION
![turboFei](https://badgen.net/badge/Hello/turboFei/green) [![Closes #462](https://badgen.net/badge/Preview/Closes%20%23462/blue)](https://github.com/yaooqinn/kyuubi/pull/462) ![69](https://badgen.net/badge/%2B/69/red) ![1](https://badgen.net/badge/-/1/green) ![2](https://badgen.net/badge/commits/2/yellow) ![Test Plan](https://badgen.net/badge/Missing/Test%20Plan/ff0000) ![Feature](https://badgen.net/badge/Label/Feature/) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=yaooqinn&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/yaooqinn/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
Currently, the engine uses hardcoded show databases to force initialization with catalog eagerly bootstrapping too.

We can make it configurable with a comma separate query list and select current_database() might be used as default since it's more lightweight than show databases in real-world cases


### _How was this patch tested?_
Existing UT.