### PR TITLE
[KYUUBI #479][TEST] Fix flaky test "BindException: Cannot assign requested address"

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/FrontendServiceSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/FrontendServiceSuite.scala
@@ -37,6 +37,7 @@ class FrontendServiceSuite extends KyuubiFunSuite {
 
   protected val server = new NoopServer()
   protected val conf = KyuubiConf()
+    .set(KyuubiConf.FRONTEND_BIND_HOST, "127.0.0.1")
     .set(KyuubiConf.FRONTEND_BIND_PORT, 0)
     .set("kyuubi.test.server.should.fail", "false")
 


### PR DESCRIPTION
![turboFei](https://badgen.net/badge/Hello/turboFei/green) [![Closes #480](https://badgen.net/badge/Preview/Closes%20%23480/blue)](https://github.com/yaooqinn/kyuubi/pull/480) ![1](https://badgen.net/badge/%2B/1/red) ![0](https://badgen.net/badge/-/0/green) ![1](https://badgen.net/badge/commits/1/yellow) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=yaooqinn&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/yaooqinn/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To fix flaky test "BindException: Cannot assign requested address".
https://github.com/yaooqinn/kyuubi/runs/2258848387?check_suite_focus=true

![image](https://user-images.githubusercontent.com/6757692/113473923-2c5dfc80-949f-11eb-9e3d-1f5b179e709c.png)
It might be caused by the build env issue.
After setting FRONTEND_BIND_HOST to 127.0.0.1, the canonical host name would be localhost, I think it can make the build job more stable.
```
scala> val serverHost = None
val serverHost: None.type = None

scala> serverHost.map(InetAddress.getByName).getOrElse(InetAddress.getLocalHost).getCanonicalHostName
val res7: String = 192.168.3.20

scala> val serverHost = Some("127.0.0.1")
val serverHost: Some[String] = Some(127.0.0.1)

scala> serverHost.map(InetAddress.getByName).getOrElse(InetAddress.getLocalHost).getCanonicalHostName
val res6: String = localhost
```

### _How was this patch tested?_
Existing UT.

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request