### PR TITLE
[KYUUBI #479][TEST][FOLLOWUP] Bind host to 127.0.0.1 in initialize

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/KyuubiFunSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/KyuubiFunSuite.scala
@@ -35,9 +35,9 @@ trait KyuubiFunSuite extends FunSuite
   with ThreadAudit
   with Logging {
   // scalastyle:on
+  System.setProperty(KyuubiConf.FRONTEND_BIND_HOST.key, "127.0.0.1")
   override def beforeAll(): Unit = {
     System.setProperty(IS_TESTING.key, "true")
-    System.setProperty(KyuubiConf.FRONTEND_BIND_HOST.key, "127.0.0.1")
     doThreadPostAudit()
     super.beforeAll()
   }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/KyuubiFunSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/KyuubiFunSuite.scala
@@ -36,6 +36,7 @@ trait KyuubiFunSuite extends FunSuite
   with Logging {
   // scalastyle:on
   System.setProperty(KyuubiConf.FRONTEND_BIND_HOST.key, "127.0.0.1")
+  System.setProperty("spark.driver.bindAddress", "127.0.0.1")
   override def beforeAll(): Unit = {
     System.setProperty(IS_TESTING.key, "true")
     doThreadPostAudit()

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/KyuubiFunSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/KyuubiFunSuite.scala
@@ -36,7 +36,6 @@ trait KyuubiFunSuite extends FunSuite
   with Logging {
   // scalastyle:on
   System.setProperty(KyuubiConf.FRONTEND_BIND_HOST.key, "127.0.0.1")
-  System.setProperty("spark.driver.bindAddress", "127.0.0.1")
   override def beforeAll(): Unit = {
     System.setProperty(IS_TESTING.key, "true")
     doThreadPostAudit()


### PR DESCRIPTION
![turboFei](https://badgen.net/badge/Hello/turboFei/green) [![Closes #489](https://badgen.net/badge/Preview/Closes%20%23489/blue)](https://github.com/yaooqinn/kyuubi/pull/489) ![1](https://badgen.net/badge/%2B/1/red) ![1](https://badgen.net/badge/-/1/green) ![3](https://badgen.net/badge/commits/3/yellow) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=yaooqinn&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

### _Why are the changes needed?_
Bind host to 127.0.0.1 in initialize phase, so that even some  suite override the beforeAll method and invoke super.beforeAll after start service.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request